### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Control your Things.app tasks directly from Claude Code, Claude Desktop, Cursor, and other AI assistants using the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/@BMPixel/things-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@BMPixel/things-mcp/badge" alt="Things Server MCP server" />
+</a>
+
 ## What It Does
 
 This MCP server lets AI assistants interact with your Things.app tasks on macOS. You can:


### PR DESCRIPTION
This PR adds a badge for the [Things MCP Server](https://glama.ai/mcp/servers/@BMPixel/things-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@BMPixel/things-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@BMPixel/things-mcp/badge" alt="Things Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.